### PR TITLE
refactor: padronizar banco de dados em português

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -2,12 +2,12 @@ CREATE DATABASE IF NOT EXISTS comandas_db;
 
 USE comandas_db;
 
-CREATE TABLE IF NOT EXISTS categories (
-    category_id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(100) NOT NULL UNIQUE
+CREATE TABLE IF NOT EXISTS categorias (
+    categoria_id INT AUTO_INCREMENT PRIMARY KEY,
+    nome VARCHAR(100) NOT NULL UNIQUE
 );
 
-INSERT IGNORE INTO categories (name)
+INSERT IGNORE INTO categorias (nome)
 VALUES
     ('Bebidas'),
     ('Frios'),
@@ -15,50 +15,50 @@ VALUES
     ('Pizzas'),
     ('Sobremesas');
 
-CREATE TABLE IF NOT EXISTS products (
-    product_id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(100) NOT NULL,
-    price DECIMAL(10,2) NOT NULL,
-    category_id INT NOT NULL,
-    active BOOLEAN NOT NULL DEFAULT TRUE,
-    CHECK (price >= 0),
-    FOREIGN KEY (category_id)
-        REFERENCES categories(category_id),
-    INDEX idx_products_category_active (category_id, active)
+CREATE TABLE IF NOT EXISTS produtos (
+    produto_id INT AUTO_INCREMENT PRIMARY KEY,
+    nome VARCHAR(100) NOT NULL,
+    preco DECIMAL(10,2) NOT NULL,
+    categoria_id INT NOT NULL,
+    ativo BOOLEAN NOT NULL DEFAULT TRUE,
+    CHECK (preco >= 0),
+    FOREIGN KEY (categoria_id)
+        REFERENCES categorias(categoria_id),
+    INDEX idx_produtos_categoria_ativo (categoria_id, ativo)
 );
 
-INSERT INTO products (name, price, category_id)
-SELECT 'Coca-Cola', 7.50, category_id
-FROM categories
-WHERE name = 'Bebidas'
+INSERT INTO produtos (nome, preco, categoria_id)
+SELECT 'Coca-Cola', 7.50, categoria_id
+FROM categorias
+WHERE nome = 'Bebidas'
 AND NOT EXISTS (
-    SELECT 1 FROM products WHERE name = 'Coca-Cola'
+    SELECT 1 FROM produtos WHERE nome = 'Coca-Cola'
 );
 
-INSERT INTO products (name, price, category_id)
-SELECT 'X-Salada', 22.90, category_id
-FROM categories
-WHERE name = 'Lanches'
+INSERT INTO produtos (nome, preco, categoria_id)
+SELECT 'X-Salada', 22.90, categoria_id
+FROM categorias
+WHERE nome = 'Lanches'
 AND NOT EXISTS (
-    SELECT 1 FROM products WHERE name = 'X-Salada'
+    SELECT 1 FROM produtos WHERE nome = 'X-Salada'
 );
 
-INSERT INTO products (name, price, category_id)
-SELECT 'Pudim', 9.00, category_id
-FROM categories
-WHERE name = 'Sobremesas'
+INSERT INTO produtos (nome, preco, categoria_id)
+SELECT 'Pudim', 9.00, categoria_id
+FROM categorias
+WHERE nome = 'Sobremesas'
 AND NOT EXISTS (
-    SELECT 1 FROM products WHERE name = 'Pudim'
+    SELECT 1 FROM produtos WHERE nome = 'Pudim'
 );
 
-CREATE TABLE IF NOT EXISTS command_cards (
-    card_id INT AUTO_INCREMENT PRIMARY KEY,
-    card_number CHAR(4) NOT NULL UNIQUE,
-    active BOOLEAN NOT NULL DEFAULT TRUE,
-    CHECK (card_number REGEXP '^[0-9]{4}$')
+CREATE TABLE IF NOT EXISTS comandas (
+    comanda_id INT AUTO_INCREMENT PRIMARY KEY,
+    numero_comanda CHAR(4) NOT NULL UNIQUE,
+    ativa BOOLEAN NOT NULL DEFAULT TRUE,
+    CHECK (numero_comanda REGEXP '^[0-9]{4}$')
 );
 
-INSERT IGNORE INTO command_cards (card_number)
+INSERT IGNORE INTO comandas (numero_comanda)
 VALUES
     ('0001'),
     ('0002'),
@@ -66,167 +66,167 @@ VALUES
     ('0004'),
     ('0005');
 
-CREATE TABLE IF NOT EXISTS orders (
-    order_id INT AUTO_INCREMENT PRIMARY KEY,
-    card_id INT NOT NULL,
-    status ENUM('open', 'closed') NOT NULL DEFAULT 'open',
-    opened_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    closed_at DATETIME NULL,
-    open_card_id INT
+CREATE TABLE IF NOT EXISTS pedidos (
+    pedido_id INT AUTO_INCREMENT PRIMARY KEY,
+    comanda_id INT NOT NULL,
+    status ENUM('aberto', 'fechado') NOT NULL DEFAULT 'aberto',
+    aberto_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    fechado_em DATETIME NULL,
+    comanda_aberta_id INT
         GENERATED ALWAYS AS (
             CASE
-                WHEN status = 'open' THEN card_id
+                WHEN status = 'aberto' THEN comanda_id
                 ELSE NULL
             END
         ) STORED,
-    UNIQUE (open_card_id),
+    UNIQUE (comanda_aberta_id),
     CHECK (
-        (status = 'open' AND closed_at IS NULL)
+        (status = 'aberto' AND fechado_em IS NULL)
         OR
-        (status = 'closed' AND closed_at IS NOT NULL)
+        (status = 'fechado' AND fechado_em IS NOT NULL)
     ),
-    FOREIGN KEY (card_id)
-        REFERENCES command_cards(card_id),
-    INDEX idx_orders_status (status)
+    FOREIGN KEY (comanda_id)
+        REFERENCES comandas(comanda_id),
+    INDEX idx_pedidos_status (status)
 );
 
-CREATE TABLE IF NOT EXISTS order_items (
-    order_item_id INT AUTO_INCREMENT PRIMARY KEY,
-    order_id INT NOT NULL,
-    product_id INT NOT NULL,
-    quantity INT NOT NULL,
-    unit_price DECIMAL(10,2) NOT NULL,
-    notes VARCHAR(255) NULL,
-    CHECK (quantity > 0),
-    CHECK (unit_price >= 0),
-    FOREIGN KEY (order_id)
-        REFERENCES orders(order_id),
-    FOREIGN KEY (product_id)
-        REFERENCES products(product_id),
-    INDEX idx_order_items_order (order_id),
-    INDEX idx_order_items_product (product_id)
+CREATE TABLE IF NOT EXISTS itens_pedido (
+    item_pedido_id INT AUTO_INCREMENT PRIMARY KEY,
+    pedido_id INT NOT NULL,
+    produto_id INT NOT NULL,
+    quantidade INT NOT NULL,
+    preco_unitario DECIMAL(10,2) NOT NULL,
+    observacoes VARCHAR(255) NULL,
+    CHECK (quantidade > 0),
+    CHECK (preco_unitario >= 0),
+    FOREIGN KEY (pedido_id)
+        REFERENCES pedidos(pedido_id),
+    FOREIGN KEY (produto_id)
+        REFERENCES produtos(produto_id),
+    INDEX idx_itens_pedido_pedido (pedido_id),
+    INDEX idx_itens_pedido_produto (produto_id)
 );
 
-CREATE TABLE IF NOT EXISTS sales (
-    sale_id INT AUTO_INCREMENT PRIMARY KEY,
-    order_id INT NOT NULL UNIQUE,
-    total_amount DECIMAL(10,2) NOT NULL,
-    payment_method ENUM('cash', 'credit', 'debit', 'pix') NOT NULL,
-    sold_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CHECK (total_amount >= 0),
-    FOREIGN KEY (order_id)
-        REFERENCES orders(order_id),
-    INDEX idx_sales_sold_at (sold_at),
-    INDEX idx_sales_payment_method (payment_method)
+CREATE TABLE IF NOT EXISTS vendas (
+    venda_id INT AUTO_INCREMENT PRIMARY KEY,
+    pedido_id INT NOT NULL UNIQUE,
+    valor_total DECIMAL(10,2) NOT NULL,
+    forma_pagamento ENUM('dinheiro', 'credito', 'debito', 'pix') NOT NULL,
+    vendido_em DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (valor_total >= 0),
+    FOREIGN KEY (pedido_id)
+        REFERENCES pedidos(pedido_id),
+    INDEX idx_vendas_vendido_em (vendido_em),
+    INDEX idx_vendas_forma_pagamento (forma_pagamento)
 );
 
-CREATE OR REPLACE VIEW vw_products AS
+CREATE OR REPLACE VIEW vw_produtos AS
 SELECT
-    p.product_id,
-    p.name AS product_name,
-    p.price,
-    c.category_id,
-    c.name AS category_name,
-    p.active
-FROM products p
-JOIN categories c
-    ON p.category_id = c.category_id;
+    p.produto_id,
+    p.nome AS nome_produto,
+    p.preco,
+    c.categoria_id,
+    c.nome AS nome_categoria,
+    p.ativo
+FROM produtos p
+JOIN categorias c
+    ON p.categoria_id = c.categoria_id;
 
-CREATE OR REPLACE VIEW vw_open_orders AS
+CREATE OR REPLACE VIEW vw_comandas_abertas AS
 SELECT
-    o.order_id,
-    cc.card_number,
-    o.status,
-    DATE_FORMAT(o.opened_at, '%H:%i  %d/%m/%Y') AS opened_at,
-    COALESCE(SUM(oi.quantity * oi.unit_price), 0) AS total_amount
-FROM orders o
-JOIN command_cards cc
-    ON o.card_id = cc.card_id
-LEFT JOIN order_items oi
-    ON o.order_id = oi.order_id
-WHERE o.status = 'open'
+    p.pedido_id,
+    c.numero_comanda,
+    p.status,
+    DATE_FORMAT(p.aberto_em, '%H:%i  %d/%m/%Y') AS aberto_em,
+    COALESCE(SUM(ip.quantidade * ip.preco_unitario), 0) AS valor_total
+FROM pedidos p
+JOIN comandas c
+    ON p.comanda_id = c.comanda_id
+LEFT JOIN itens_pedido ip
+    ON p.pedido_id = ip.pedido_id
+WHERE p.status = 'aberto'
 GROUP BY
-    o.order_id,
-    cc.card_number,
-    o.status,
-    o.opened_at;
+    p.pedido_id,
+    c.numero_comanda,
+    p.status,
+    p.aberto_em;
 
-CREATE OR REPLACE VIEW vw_order_summary AS
+CREATE OR REPLACE VIEW vw_resumo_pedido AS
 SELECT
-    o.order_id,
-    cc.card_number,
-    o.status,
-    DATE_FORMAT(o.opened_at, '%H:%i  %d/%m/%Y') AS opened_at,
-    DATE_FORMAT(o.closed_at, '%H:%i  %d/%m/%Y') AS closed_at,
-    p.product_id,
-    p.name AS product_name,
-    c.name AS category_name,
-    oi.quantity,
-    oi.unit_price,
-    oi.quantity * oi.unit_price AS subtotal,
-    oi.notes,
-    SUM(oi.quantity * oi.unit_price)
-        OVER (PARTITION BY o.order_id) AS order_total
-FROM orders o
-JOIN command_cards cc
-    ON o.card_id = cc.card_id
-JOIN order_items oi
-    ON o.order_id = oi.order_id
-JOIN products p
-    ON oi.product_id = p.product_id
-JOIN categories c
-    ON p.category_id = c.category_id;
+    pe.pedido_id,
+    co.numero_comanda,
+    pe.status,
+    DATE_FORMAT(pe.aberto_em, '%H:%i  %d/%m/%Y') AS aberto_em,
+    DATE_FORMAT(pe.fechado_em, '%H:%i  %d/%m/%Y') AS fechado_em,
+    pr.produto_id,
+    pr.nome AS nome_produto,
+    ca.nome AS nome_categoria,
+    ip.quantidade,
+    ip.preco_unitario,
+    ip.quantidade * ip.preco_unitario AS subtotal,
+    ip.observacoes,
+    SUM(ip.quantidade * ip.preco_unitario)
+        OVER (PARTITION BY pe.pedido_id) AS total_pedido
+FROM pedidos pe
+JOIN comandas co
+    ON pe.comanda_id = co.comanda_id
+JOIN itens_pedido ip
+    ON pe.pedido_id = ip.pedido_id
+JOIN produtos pr
+    ON ip.produto_id = pr.produto_id
+JOIN categorias ca
+    ON pr.categoria_id = ca.categoria_id;
 
-CREATE OR REPLACE VIEW vw_sales_history AS
+CREATE OR REPLACE VIEW vw_historico_vendas AS
 SELECT
-    s.sale_id,
-    s.order_id,
-    cc.card_number,
-    s.total_amount,
-    s.payment_method,
-    CASE s.payment_method
-        WHEN 'cash' THEN 'Dinheiro'
-        WHEN 'credit' THEN 'Crédito'
-        WHEN 'debit' THEN 'Débito'
+    v.venda_id,
+    v.pedido_id,
+    c.numero_comanda,
+    v.valor_total,
+    v.forma_pagamento,
+    CASE v.forma_pagamento
+        WHEN 'dinheiro' THEN 'Dinheiro'
+        WHEN 'credito' THEN 'Crédito'
+        WHEN 'debito' THEN 'Débito'
         WHEN 'pix' THEN 'PIX'
-    END AS payment_method_label,
-    DATE_FORMAT(s.sold_at, '%H:%i  %d/%m/%Y') AS sold_at,
-    s.sold_at AS sold_at_raw
-FROM sales s
-JOIN orders o
-    ON s.order_id = o.order_id
-JOIN command_cards cc
-    ON o.card_id = cc.card_id;
+    END AS forma_pagamento_descricao,
+    DATE_FORMAT(v.vendido_em, '%H:%i  %d/%m/%Y') AS vendido_em,
+    v.vendido_em AS vendido_em_original
+FROM vendas v
+JOIN pedidos p
+    ON v.pedido_id = p.pedido_id
+JOIN comandas c
+    ON p.comanda_id = c.comanda_id;
 
-CREATE OR REPLACE VIEW vw_daily_summary AS
+CREATE OR REPLACE VIEW vw_resumo_diario AS
 SELECT
-    DATE(sold_at) AS summary_date,
-    DATE_FORMAT(sold_at, '%d/%m/%Y') AS date_label,
-    COUNT(*) AS total_sales,
-    SUM(total_amount) AS total_revenue,
-    AVG(total_amount) AS average_ticket
-FROM sales
-GROUP BY DATE(sold_at), DATE_FORMAT(sold_at, '%d/%m/%Y');
+    DATE(vendido_em) AS data_resumo,
+    DATE_FORMAT(vendido_em, '%d/%m/%Y') AS data_formatada,
+    COUNT(*) AS total_vendas,
+    SUM(valor_total) AS faturamento_total,
+    AVG(valor_total) AS ticket_medio
+FROM vendas
+GROUP BY DATE(vendido_em), DATE_FORMAT(vendido_em, '%d/%m/%Y');
 
-CREATE OR REPLACE VIEW vw_weekly_summary AS
+CREATE OR REPLACE VIEW vw_resumo_semanal AS
 SELECT
-    YEARWEEK(sold_at, 1) AS year_week,
-    COUNT(*) AS total_sales,
-    SUM(total_amount) AS total_revenue,
-    AVG(total_amount) AS average_ticket
-FROM sales
-GROUP BY YEARWEEK(sold_at, 1);
+    YEARWEEK(vendido_em, 1) AS ano_semana,
+    COUNT(*) AS total_vendas,
+    SUM(valor_total) AS faturamento_total,
+    AVG(valor_total) AS ticket_medio
+FROM vendas
+GROUP BY YEARWEEK(vendido_em, 1);
 
-CREATE OR REPLACE VIEW vw_monthly_summary AS
+CREATE OR REPLACE VIEW vw_resumo_mensal AS
 SELECT
-    YEAR(sold_at) AS year,
-    MONTH(sold_at) AS month,
-    DATE_FORMAT(sold_at, '%m/%Y') AS month_label,
-    COUNT(*) AS total_sales,
-    SUM(total_amount) AS total_revenue,
-    AVG(total_amount) AS average_ticket
-FROM sales
+    YEAR(vendido_em) AS ano,
+    MONTH(vendido_em) AS mes,
+    DATE_FORMAT(vendido_em, '%m/%Y') AS mes_formatado,
+    COUNT(*) AS total_vendas,
+    SUM(valor_total) AS faturamento_total,
+    AVG(valor_total) AS ticket_medio
+FROM vendas
 GROUP BY
-    YEAR(sold_at),
-    MONTH(sold_at),
-    DATE_FORMAT(sold_at, '%m/%Y');
+    YEAR(vendido_em),
+    MONTH(vendido_em),
+    DATE_FORMAT(vendido_em, '%m/%Y');

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -2,39 +2,41 @@
 
 O projeto utiliza **MySQL 8** como banco relacional. O schema oficial está em [`database/schema.sql`](../database/schema.sql) e foi pensado para suportar as telas e fluxos definidos no Figma: produtos, comandas, pagamento, histórico e resumos por dia, semana e mês.
 
+A nomenclatura das tabelas, colunas, views, índices e valores de domínio foi padronizada em **português** para manter o banco coerente com o projeto e facilitar a leitura durante o desenvolvimento.
+
 ## Estrutura atual
 
-### `categories`
+### `categorias`
 Classifica os produtos. O nome da categoria é único para evitar duplicidades.
 
-### `products`
+### `produtos`
 Armazena nome, preço atual, categoria e status ativo/inativo. Produtos desativados continuam existindo para preservar referências históricas.
 
-### `command_cards`
+### `comandas`
 Representa as comandas físicas do estabelecimento. O número possui quatro dígitos e é reutilizável após o fechamento de um atendimento.
 
-### `orders`
+### `pedidos`
 Representa cada utilização de uma comanda física. Uma mesma comanda pode gerar muitos pedidos ao longo do tempo, mas somente um deles pode permanecer aberto por vez.
 
-A coluna gerada `open_card_id` combinada com `UNIQUE` garante essa regra diretamente no banco: quando o pedido está aberto, ela recebe o `card_id`; quando fecha, passa a `NULL` e o número pode ser reutilizado.
+A coluna gerada `comanda_aberta_id` combinada com `UNIQUE` garante essa regra diretamente no banco: quando o pedido está aberto, ela recebe o `comanda_id`; quando fecha, passa a `NULL` e o número pode ser reutilizado.
 
-### `order_items`
+### `itens_pedido`
 Liga produtos aos pedidos e registra quantidade, preço unitário no momento do consumo e observações. O preço é copiado para o item para que alterações futuras no catálogo não modifiquem vendas antigas.
 
-### `sales`
-Registra o fechamento financeiro de um pedido, incluindo total, forma de pagamento e data/hora. Cada pedido pode gerar no máximo uma venda.
+### `vendas`
+Registra o fechamento financeiro de um pedido, incluindo valor total, forma de pagamento e data/hora. Cada pedido pode gerar no máximo uma venda.
 
 ## Views
 
 As views funcionam como consultas reutilizáveis que simplificam a futura API e correspondem às principais telas do Figma.
 
-- `vw_products`: catálogo com categoria e status.
-- `vw_open_orders`: comandas abertas e total atual.
-- `vw_order_summary`: itens, subtotais e total de uma comanda.
-- `vw_sales_history`: histórico de vendas com número da comanda e forma de pagamento legível.
-- `vw_daily_summary`: quantidade de vendas, faturamento e ticket médio por dia.
-- `vw_weekly_summary`: consolidação semanal.
-- `vw_monthly_summary`: consolidação mensal.
+- `vw_produtos`: catálogo com categoria e status.
+- `vw_comandas_abertas`: comandas abertas e total atual.
+- `vw_resumo_pedido`: itens, subtotais e total de uma comanda.
+- `vw_historico_vendas`: histórico de vendas com número da comanda e forma de pagamento legível.
+- `vw_resumo_diario`: quantidade de vendas, faturamento e ticket médio por dia.
+- `vw_resumo_semanal`: consolidação semanal.
+- `vw_resumo_mensal`: consolidação mensal.
 
 ## Recursos SQL utilizados
 
@@ -42,13 +44,13 @@ As views funcionam como consultas reutilizáveis que simplificam a futura API e 
 Fornecem uma identidade interna estável para cada registro e geram os IDs automaticamente.
 
 ### `FOREIGN KEY`
-Mantém integridade referencial entre categorias, produtos, comandas, itens e vendas.
+Mantém integridade referencial entre categorias, produtos, comandas, pedidos, itens e vendas.
 
 ### `CHECK`
 Impõe regras como preço não negativo, quantidade maior que zero e número da comanda com exatamente quatro dígitos numéricos.
 
 ### `ENUM`
-Restringe estados e formas de pagamento aos valores aceitos pelo domínio.
+Restringe estados e formas de pagamento aos valores aceitos pelo domínio. No schema atual, os pedidos usam `aberto` e `fechado`; as vendas usam `dinheiro`, `credito`, `debito` e `pix`.
 
 ### Coluna gerada + `UNIQUE`
 Impede que uma mesma comanda física esteja aberta em dois atendimentos simultâneos.
@@ -66,7 +68,7 @@ Foram adicionados índices nos campos usados com frequência em filtros e relaci
 
 1. Abra o MySQL Workbench e conecte-se ao MySQL 8.
 2. Abra `database/schema.sql`.
-3. Execute o script completo.
+3. Execute o script completo em um banco novo.
 4. Atualize a área **Schemas**.
 5. Verifique as tabelas com:
 
@@ -89,6 +91,12 @@ O banco mantém valores `DATETIME` de forma nativa. A apresentação usada nas v
 ```
 
 Isso é feito com `DATE_FORMAT`, preservando o tipo correto no armazenamento.
+
+## Atenção sobre bancos já criados
+
+A alteração dos nomes para português muda a estrutura lógica do schema. `CREATE TABLE IF NOT EXISTS` não renomeia tabelas antigas automaticamente.
+
+Enquanto o banco estiver apenas em desenvolvimento e sem dados importantes, a opção mais simples é criar um schema limpo usando o arquivo atualizado. Quando o projeto possuir dados persistentes importantes, mudanças desse tipo deverão ser feitas por **migrations**, sem apagar o banco.
 
 ## Próximas evoluções
 


### PR DESCRIPTION
## Resumo

Padroniza a nomenclatura do banco de dados do FluxoPag em português.

## Alterações

- traduz tabelas, colunas, views, índices e valores de domínio;
- mantém a estrutura e as regras de integridade existentes;
- atualiza `docs/DATABASE.md` com a nova nomenclatura;
- atualiza as issues #10 e #11 para refletir os novos nomes.

## Exemplos

- `categories` → `categorias`
- `products` → `produtos`
- `command_cards` → `comandas`
- `orders` → `pedidos`
- `order_items` → `itens_pedido`
- `sales` → `vendas`
- `vw_open_orders` → `vw_comandas_abertas`
- `vw_sales_history` → `vw_historico_vendas`

## Observação

Como esta alteração renomeia a estrutura lógica do banco, bancos já criados anteriormente não serão modificados apenas com `IF NOT EXISTS`. Durante o estágio atual de desenvolvimento, recomenda-se recriar o schema limpo com o arquivo atualizado. Futuramente, essa evolução será feita por migrations.